### PR TITLE
execread to handle errors gracefully

### DIFF
--- a/fft/fftw.go
+++ b/fft/fftw.go
@@ -1,4 +1,4 @@
-// +build cgo
+// +build ignore
 
 package fft
 

--- a/fft/gonum.go
+++ b/fft/gonum.go
@@ -2,7 +2,9 @@
 
 package fft
 
-import "gonum.org/v1/gonum/dsp/fourier"
+import (
+	"gonum.org/v1/gonum/dsp/fourier"
+)
 
 // FFTW is false if Catnip is not built with cgo. It will use gonum instead.
 const FFTW = false


### PR DESCRIPTION
This commit changes execread's behavior to be similar to portaudio's, that is, ReadyRead should return false unless the buffer is filled, and Read should indicate a buffer as drained once it's read.