### PR TITLE
Add color flags

### DIFF
--- a/catnip.go
+++ b/catnip.go
@@ -108,6 +108,7 @@ func Catnip(cfg *Config) error {
 	display.SetWidths(cfg.BarWidth, cfg.SpaceWidth)
 	display.SetBase(cfg.BaseThick)
 	display.SetDrawType(graphic.DrawType(cfg.DrawType))
+	display.SetStyles(cfg.Styles)
 
 	var endSig = make(chan os.Signal, 2)
 	signal.Notify(endSig, os.Interrupt)

--- a/config.go
+++ b/config.go
@@ -35,6 +35,8 @@ type Config struct {
 	ChannelCount int
 	// DrawType is the draw type
 	DrawType int
+	// Styles is the configuration for bar color styles
+	Styles graphic.Styles
 	// SpectrumType is the spectrum calculation method
 	SpectrumType int
 	// FFTSize is the size

--- a/fft/fftw.go
+++ b/fft/fftw.go
@@ -1,4 +1,4 @@
-// +build ignore
+// +build cgo
 
 package fft
 

--- a/fft/fftw.go
+++ b/fft/fftw.go
@@ -1,4 +1,4 @@
-// +build cgo
+// +build ignore
 
 package fft
 

--- a/fft/gonum.go
+++ b/fft/gonum.go
@@ -2,7 +2,9 @@
 
 package fft
 
-import "gonum.org/v1/gonum/dsp/fourier"
+import (
+	"gonum.org/v1/gonum/dsp/fourier"
+)
 
 // FFTW is false if Catnip is not built with cgo. It will use gonum instead.
 const FFTW = false

--- a/graphic/display.go
+++ b/graphic/display.go
@@ -17,12 +17,6 @@ const (
 	BarRuneR = '\u2580'
 	BarRune  = '\u2588'
 
-	// styles
-
-	StyleDefault     = termbox.ColorDefault
-	StyleDefaultBack = termbox.ColorDefault
-	StyleCenter      = termbox.ColorMagenta
-	// StyleCenter  = StyleDefault
 	StyleReverse = termbox.AttrReverse
 
 	// NumRunes number of runes for sub step bars
@@ -44,6 +38,39 @@ const (
 	DrawDefault = DrawUpDown
 )
 
+// Styles is the structure for the styles that Display will draw using.
+type Styles struct {
+	Foreground termbox.Attribute
+	Background termbox.Attribute
+	CenterLine termbox.Attribute
+}
+
+// DefaultStyles returns the default styles.
+func DefaultStyles() Styles {
+	return Styles{
+		Foreground: termbox.ColorDefault,
+		Background: termbox.ColorDefault,
+		CenterLine: termbox.ColorMagenta,
+	}
+}
+
+// StylesFromUInt16 converts 3 uint16 values to styles.
+func StylesFromUInt16(fg, bg, center uint16) Styles {
+	return Styles{
+		Foreground: termbox.Attribute(fg),
+		Background: termbox.Attribute(bg),
+		CenterLine: termbox.Attribute(center),
+	}
+}
+
+// AsUInt16s converts the styles to 3 uint16 values.
+func (s Styles) AsUInt16s() (fg, bg, center uint16) {
+	fg = uint16(s.Foreground)
+	bg = uint16(s.Background)
+	center = uint16(s.CenterLine)
+	return
+}
+
 // Display handles drawing our visualizer
 type Display struct {
 	running    uint32
@@ -54,6 +81,7 @@ type Display struct {
 	termWidth  int
 	termHeight int
 	drawType   DrawType
+	styles     Styles
 }
 
 // Init initializes the display
@@ -181,7 +209,7 @@ func (d *Display) Draw(bufs [][]float64, channels, count int, scale float64) err
 
 	termbox.Flush()
 
-	termbox.Clear(StyleDefault, StyleDefaultBack)
+	termbox.Clear(d.styles.Foreground, d.styles.Background)
 
 	return nil
 }
@@ -219,6 +247,12 @@ func (d *Display) SetBase(thick int) {
 		d.baseThick = thick
 
 	}
+}
+
+func (d *Display) SetStyles(styles Styles) {
+	if styles.Background > 266 {
+	}
+	d.styles = styles
 }
 
 // AdjustBase will change the base by delta units
@@ -328,15 +362,15 @@ func (d *Display) DrawUp(bins [][]float64, count int, scale float64) error {
 			var xRow = d.termHeight
 
 			for ; xRow >= vHeight; xRow-- {
-				termbox.SetCell(xCol, xRow, BarRune, StyleCenter, StyleDefaultBack)
+				termbox.SetCell(xCol, xRow, BarRune, d.styles.CenterLine, d.styles.Background)
 			}
 
 			for ; xRow >= stop; xRow-- {
-				termbox.SetCell(xCol, xRow, BarRune, StyleDefault, StyleDefaultBack)
+				termbox.SetCell(xCol, xRow, BarRune, d.styles.Foreground, d.styles.Background)
 			}
 
 			if top > BarRuneR {
-				termbox.SetCell(xCol, xRow, top, StyleDefault, StyleDefaultBack)
+				termbox.SetCell(xCol, xRow, top, d.styles.Foreground, d.styles.Background)
 			}
 		}
 
@@ -400,15 +434,15 @@ func (d *Display) DrawDown(bins [][]float64, count int, scale float64) error {
 			var xRow = 0
 
 			for ; xRow < d.baseThick; xRow++ {
-				termbox.SetCell(xCol, xRow, BarRune, StyleCenter, StyleDefaultBack)
+				termbox.SetCell(xCol, xRow, BarRune, d.styles.CenterLine, d.styles.Background)
 			}
 
 			for ; xRow < stop; xRow++ {
-				termbox.SetCell(xCol, xRow, BarRune, StyleDefault, StyleDefaultBack)
+				termbox.SetCell(xCol, xRow, BarRune, d.styles.Foreground, d.styles.Background)
 			}
 
 			if top < BarRune {
-				termbox.SetCell(xCol, xRow, top, StyleReverse, StyleDefault)
+				termbox.SetCell(xCol, xRow, top, StyleReverse, d.styles.Foreground)
 			}
 
 			xCol++
@@ -483,26 +517,26 @@ func (d *Display) DrawUpDown(bins [][]float64, count int, scale float64) error {
 		var xRow = lStop
 
 		if lTop > BarRuneR {
-			termbox.SetCell(xCol, xRow-1, lTop, StyleDefault, StyleDefaultBack)
+			termbox.SetCell(xCol, xRow-1, lTop, d.styles.Foreground, d.styles.Background)
 		}
 
 		for ; xRow < centerStart; xRow++ {
-			termbox.SetCell(xCol, xRow, BarRune, StyleDefault, StyleDefaultBack)
+			termbox.SetCell(xCol, xRow, BarRune, d.styles.Foreground, d.styles.Background)
 		}
 
 		// center line
 		for ; xRow < centerStop; xRow++ {
-			termbox.SetCell(xCol, xRow, BarRune, StyleCenter, StyleDefaultBack)
+			termbox.SetCell(xCol, xRow, BarRune, d.styles.CenterLine, d.styles.Background)
 		}
 
 		// right bars go down
 		for ; xRow < rStop; xRow++ {
-			termbox.SetCell(xCol, xRow, BarRune, StyleDefault, StyleDefaultBack)
+			termbox.SetCell(xCol, xRow, BarRune, d.styles.Foreground, d.styles.Background)
 		}
 
 		// last part of right bars.
 		if rTop < BarRune {
-			termbox.SetCell(xCol, xRow, rTop, StyleReverse, StyleDefault)
+			termbox.SetCell(xCol, xRow, rTop, StyleReverse, d.styles.Foreground)
 		}
 	}
 


### PR DESCRIPTION
    This commit adds the -fg|--foreground, -bg|--background and
    -ct|--center flag to change the colors of the visualizer.
    
    In addition to the above changes, graphic.Styles is added to accomodate
    for the above change. A few minor refactors were also done.

This PR is blocked on #5.