### PR TITLE
Flush execread buffer for latency

### DIFF
--- a/input/parec/parec.go
+++ b/input/parec/parec.go
@@ -53,6 +53,7 @@ func (p Backend) Start(cfg input.SessionConfig) (input.Session, error) {
 
 type PulseDevice string
 
+// InputArgs is used for FFmpeg only.
 func (d PulseDevice) InputArgs() []string {
 	return []string{"-f", "pulse", "-i", string(d)}
 }


### PR DESCRIPTION
This commit makes execread attempt to flush everything but the latest buffer chunk, so that the data read from the buffer is always the latest data if it ever overflows.